### PR TITLE
Fix TCC set temperature when in auto mode

### DIFF
--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -182,6 +182,12 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         device: LyricDevice,
     ) -> None:
         """Initialize Honeywell Lyric climate entity."""
+        # Define thermostat type (TCC - e.g., Lyric round; LCC - e.g., T5,6)
+        if device.changeableValues.thermostatSetpointStatus:
+            self._attr_thermostat_type = LyricThermostatType.LCC
+        else:
+            self._attr_thermostat_type = LyricThermostatType.TCC
+
         # Use the native temperature unit from the device settings
         if device.units == "Fahrenheit":
             self._attr_temperature_unit = UnitOfTemperature.FAHRENHEIT
@@ -207,12 +213,10 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
             self._attr_hvac_modes.append(HVACMode.HEAT_COOL)
 
         # Setup supported features
-        if device.changeableValues.thermostatSetpointStatus:
+        if self._attr_thermostat_type == LyricThermostatType.LCC:
             self._attr_supported_features = SUPPORT_FLAGS_LCC
-            self._attr_thermostat_type = LyricThermostatType.LCC
         else:
             self._attr_supported_features = SUPPORT_FLAGS_TCC
-            self._attr_thermostat_type = LyricThermostatType.TCC
 
         # Setup supported fan modes
         if device_fan_modes := device.settings.attributes.get("fan", {}).get(
@@ -328,20 +332,19 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         target_temp_low = kwargs.get(ATTR_TARGET_TEMP_LOW)
         target_temp_high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
 
-        if device.changeableValues.autoChangeoverActive:
+        if device.changeableValues.mode == LYRIC_HVAC_MODE_HEAT_COOL:
             if target_temp_low is None or target_temp_high is None:
                 raise HomeAssistantError(
                     "Could not find target_temp_low and/or target_temp_high in"
                     " arguments"
                 )
 
-            # If the device supports "Auto" mode, don't pass the mode when setting the
-            # temperature
-            mode = (
-                None
-                if device.changeableValues.mode == LYRIC_HVAC_MODE_HEAT_COOL
-                else HVAC_MODES[device.changeableValues.heatCoolMode]
-            )
+            # If TCC device pass the heatCoolMode value, otherwise
+            # if LCC device can skip the mode altogether
+            if self._attr_thermostat_type == LyricThermostatType.TCC:
+                mode=HVAC_MODES[device.changeableValues.heatCoolMode]
+            else:
+                mode=None 
 
             _LOGGER.debug("Set temperature: %s - %s", target_temp_low, target_temp_high)
             try:
@@ -385,6 +388,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         await self.coordinator.async_refresh()
 
     async def _async_set_hvac_mode_tcc(self, hvac_mode: HVACMode) -> None:
+        """Set hvac mode for TCC devices (e.g., Lyric round)."""
         if LYRIC_HVAC_MODES[hvac_mode] == LYRIC_HVAC_MODE_HEAT_COOL:
             # If the system is off, turn it to Heat first then to Auto,
             # otherwise it turns to.
@@ -432,11 +436,23 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
             )
 
     async def _async_set_hvac_mode_lcc(self, hvac_mode: HVACMode) -> None:
+        """Set hvac mode for LCC devices (e.g., T5,6)."""
         _LOGGER.debug("HVAC mode passed to lyric: %s", LYRIC_HVAC_MODES[hvac_mode])
+        # Set autoChangeoverActive to True if the mode being passed is Auto
+        # otherwise leave unchanged
+        if (
+            LYRIC_HVAC_MODES[hvac_mode] == LYRIC_HVAC_MODE_HEAT_COOL
+            and not self.changeableValues.autoChangeoverActive
+        ):
+            autoChangeover=True
+        else: 
+            autoChangeover=None
+
         await self._update_thermostat(
             self.location,
             self.device,
-            mode=LYRIC_HVAC_MODES[hvac_mode],
+            mode=LYRIC_HVAC_MODES[hvac_mode],\
+            autoChangeoverActive=autoChangeover
         )
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The recent changes made by  @apt-itude in #104853 to fix the auto mode for LCC devices unfortunately broke the `async_set_temperature` function for TCC devices (i.e., Lyric round). @apt-itude asked me to review his code, so it's really my fault for catching this so late. 

The source of the problem is the way the two types of devices use the `autoChangeoverActive` variable, as well as how they display the mode within `changeableValues`, and which modes they allow you to pass. 

For LCC devices, auto mode is enabled in two steps. First, you have to allow it by setting `autoChangeoverActive` to true. Then, you can set the `changeableValues.mode` to "Auto" within `changeableValues` when you'd like to use it. LCC devices allow modes "Off", "Heat", "Cool", and "Auto". Of note, while working on this PR I realized if the user sets `autoChangeoverActive` to false in the physical device itself, and later tries to pass mode "Auto", it will not work, so I added code to the `async_set_hvac_mode_lcc` function to take care of this. 

For TCC devices, auto mode is enabled directly by setting `autoChangeoverActive` to true or false. When you do this, `changeableValues.mode` will indeed display "Auto" (see image below). Nevertheless, TCC devices only allow you to set `changeableModes.mode` to "Off", "Heat", or "Cool", hence you can't actually pass mode="Auto" at any point or you get the the following error `Mode 7 is not allowed. Allowed modes are Cool, Heat, Off.`. This is confusing, and poor form in the way they implemented the api for TCC devices. I have no idea why they didn't just design both devices to do things the same way.

![image](https://github.com/nprez83/core/assets/41305393/bb291830-25ec-4a00-bf2d-610253ee731d)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #104853
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
